### PR TITLE
feat: full DID resolution for did:key, did:jwk, and did:web

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -14,8 +14,10 @@ import {
 	base64urlToUint8Array,
 	generateKeyPair,
 	jwkToPublicKey,
+	publicKeyToJwk,
 	uint8ArrayToBase64url,
 } from "./crypto/keys";
+import { createDidJwk } from "./did/methods/jwk";
 import { createDidKey } from "./did/methods/key";
 import { createDidWeb } from "./did/methods/web";
 import { resolveDID } from "./did/resolver";
@@ -351,6 +353,11 @@ function createDIDModule() {
 					const kp = generateKeyPair("ES256");
 					return createDidKey(kp.publicKey, "ES256");
 				}
+				case "jwk": {
+					const kp = generateKeyPair("ES256");
+					const jwk = publicKeyToJwk(kp.publicKey, "ES256");
+					return createDidJwk(jwk);
+				}
 				case "web": {
 					if (!options.domain) {
 						throw new CredatError(
@@ -364,7 +371,7 @@ function createDIDModule() {
 				default:
 					throw new CredatError(
 						ErrorCodes.INVALID_CONFIG,
-						`DID method "${options.method}" cannot be created locally. Supported: key, web.`,
+						`DID method "${options.method}" cannot be created locally. Supported: key, jwk, web.`,
 					);
 			}
 		},

--- a/src/crypto/keys.test.ts
+++ b/src/crypto/keys.test.ts
@@ -18,6 +18,13 @@ describe("generateKeyPair", () => {
 		expect(kp.publicKey.length).toBe(32);
 	});
 
+	it("generates ES256K (secp256k1) key pair", () => {
+		const kp = generateKeyPair("ES256K");
+		expect(kp.algorithm).toBe("ES256K");
+		expect(kp.privateKey.length).toBe(32);
+		expect(kp.publicKey.length).toBe(33); // compressed
+	});
+
 	it("generates unique keys each time", () => {
 		const kp1 = generateKeyPair("ES256");
 		const kp2 = generateKeyPair("ES256");
@@ -44,9 +51,26 @@ describe("publicKeyToJwk", () => {
 		expect(jwk.x).toBeDefined();
 	});
 
-	it("round-trips through JWK", () => {
+	it("converts secp256k1 public key to JWK", () => {
+		const kp = generateKeyPair("ES256K");
+		const jwk = publicKeyToJwk(kp.publicKey, "ES256K");
+		expect(jwk.kty).toBe("EC");
+		expect(jwk.crv).toBe("secp256k1");
+		expect(jwk.x).toBeDefined();
+		expect(jwk.y).toBeDefined();
+		expect(jwk.d).toBeUndefined();
+	});
+
+	it("round-trips P-256 through JWK", () => {
 		const kp = generateKeyPair("ES256");
 		const jwk = publicKeyToJwk(kp.publicKey, "ES256");
+		const restored = jwkToPublicKey(jwk);
+		expect(restored).toEqual(kp.publicKey);
+	});
+
+	it("round-trips secp256k1 through JWK", () => {
+		const kp = generateKeyPair("ES256K");
+		const jwk = publicKeyToJwk(kp.publicKey, "ES256K");
 		const restored = jwkToPublicKey(jwk);
 		expect(restored).toEqual(kp.publicKey);
 	});

--- a/src/crypto/keys.ts
+++ b/src/crypto/keys.ts
@@ -1,9 +1,10 @@
 import { ed25519 } from "@noble/curves/ed25519.js";
 import { p256 } from "@noble/curves/nist.js";
+import { secp256k1 } from "@noble/curves/secp256k1.js";
 import { bytesToHex, randomBytes } from "@noble/hashes/utils.js";
 import type { JsonWebKey } from "../types";
 
-export type Algorithm = "ES256" | "EdDSA";
+export type Algorithm = "ES256" | "EdDSA" | "ES256K";
 
 export interface KeyPair {
 	algorithm: Algorithm;
@@ -21,6 +22,11 @@ export function generateKeyPair(algorithm: Algorithm): KeyPair {
 
 	if (algorithm === "EdDSA") {
 		const publicKey = ed25519.getPublicKey(privateKey);
+		return { algorithm, privateKey, publicKey };
+	}
+
+	if (algorithm === "ES256K") {
+		const publicKey = secp256k1.getPublicKey(privateKey, true); // compressed 33 bytes
 		return { algorithm, privateKey, publicKey };
 	}
 
@@ -54,6 +60,20 @@ export function publicKeyToJwk(
 		};
 	}
 
+	if (algorithm === "ES256K") {
+		const point = secp256k1.Point.fromHex(bytesToHex(publicKey));
+		const uncompressed = point.toBytes(false); // 65 bytes: 0x04 || x || y
+		const x = uncompressed.slice(1, 33);
+		const y = uncompressed.slice(33, 65);
+
+		return {
+			kty: "EC",
+			crv: "secp256k1",
+			x: uint8ArrayToBase64url(x),
+			y: uint8ArrayToBase64url(y),
+		};
+	}
+
 	throw new Error(`Unsupported algorithm: ${algorithm}`);
 }
 
@@ -72,6 +92,17 @@ export function jwkToPublicKey(jwk: JsonWebKey): Uint8Array {
 
 	if (jwk.kty === "OKP" && jwk.crv === "Ed25519") {
 		return base64urlToUint8Array(jwk.x!);
+	}
+
+	if (jwk.kty === "EC" && jwk.crv === "secp256k1") {
+		const x = base64urlToUint8Array(jwk.x!);
+		const y = base64urlToUint8Array(jwk.y!);
+		const uncompressed = new Uint8Array(65);
+		uncompressed[0] = 0x04;
+		uncompressed.set(x, 1);
+		uncompressed.set(y, 33);
+		const point = secp256k1.Point.fromHex(bytesToHex(uncompressed));
+		return point.toBytes(true); // compressed
 	}
 
 	throw new Error(`Unsupported JWK: kty=${jwk.kty}, crv=${jwk.crv}`);

--- a/src/crypto/sign.test.ts
+++ b/src/crypto/sign.test.ts
@@ -13,6 +13,16 @@ describe("sign and verify", () => {
 		);
 	});
 
+	it("signs and verifies with ES256K", () => {
+		const kp = generateKeyPair("ES256K");
+		const payload = new TextEncoder().encode("hello eidas");
+		const signature = sign(payload, kp.privateKey, "ES256K");
+		expect(signature).toBeInstanceOf(Uint8Array);
+		expect(verifySignature(payload, signature, kp.publicKey, "ES256K")).toBe(
+			true,
+		);
+	});
+
 	it("signs and verifies with EdDSA", () => {
 		const kp = generateKeyPair("EdDSA");
 		const payload = new TextEncoder().encode("hello eidas");

--- a/src/crypto/sign.ts
+++ b/src/crypto/sign.ts
@@ -1,5 +1,6 @@
 import { ed25519 } from "@noble/curves/ed25519.js";
 import { p256 } from "@noble/curves/nist.js";
+import { secp256k1 } from "@noble/curves/secp256k1.js";
 import type { Algorithm } from "./keys";
 
 export function sign(
@@ -13,6 +14,10 @@ export function sign(
 
 	if (algorithm === "EdDSA") {
 		return ed25519.sign(payload, privateKey);
+	}
+
+	if (algorithm === "ES256K") {
+		return secp256k1.sign(payload, privateKey, { lowS: true });
 	}
 
 	throw new Error(`Unsupported algorithm: ${algorithm}`);
@@ -31,6 +36,10 @@ export function verifySignature(
 
 		if (algorithm === "EdDSA") {
 			return ed25519.verify(signature, payload, publicKey);
+		}
+
+		if (algorithm === "ES256K") {
+			return secp256k1.verify(signature, payload, publicKey, { lowS: true });
 		}
 
 		return false;

--- a/src/did/index.ts
+++ b/src/did/index.ts
@@ -1,4 +1,5 @@
 export { resolveDidEbsi } from "./methods/ebsi";
+export { createDidJwk, resolveDidJwk } from "./methods/jwk";
 export { createDidKey, resolveDidKey } from "./methods/key";
 export { createDidWeb, didWebToUrl, resolveDidWeb } from "./methods/web";
 export { resolveDID } from "./resolver";

--- a/src/did/methods/jwk.test.ts
+++ b/src/did/methods/jwk.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { generateKeyPair, publicKeyToJwk } from "../../crypto";
+import type { JsonWebKey } from "../../types";
+import { createDidJwk, resolveDidJwk } from "./jwk";
+
+describe("did:jwk", () => {
+	it("creates and resolves a P-256 JWK round-trip", () => {
+		const kp = generateKeyPair("ES256");
+		const jwk = publicKeyToJwk(kp.publicKey, "ES256");
+		const did = createDidJwk(jwk);
+		expect(did).toMatch(/^did:jwk:/);
+
+		const result = resolveDidJwk(did);
+		expect(result.didDocument).not.toBeNull();
+		expect(result.didDocument?.id).toBe(did);
+		const resolvedJwk =
+			result.didDocument?.verificationMethod?.[0]?.publicKeyJwk;
+		expect(resolvedJwk?.crv).toBe("P-256");
+		expect(resolvedJwk?.x).toBe(jwk.x);
+		expect(resolvedJwk?.y).toBe(jwk.y);
+	});
+
+	it("creates and resolves an Ed25519 JWK round-trip", () => {
+		const kp = generateKeyPair("EdDSA");
+		const jwk = publicKeyToJwk(kp.publicKey, "EdDSA");
+		const did = createDidJwk(jwk);
+
+		const result = resolveDidJwk(did);
+		expect(result.didDocument).not.toBeNull();
+		const resolvedJwk =
+			result.didDocument?.verificationMethod?.[0]?.publicKeyJwk;
+		expect(resolvedJwk?.crv).toBe("Ed25519");
+		expect(resolvedJwk?.x).toBe(jwk.x);
+	});
+
+	it("use=sig → no keyAgreement", () => {
+		const kp = generateKeyPair("ES256");
+		const jwk: JsonWebKey = {
+			...publicKeyToJwk(kp.publicKey, "ES256"),
+			use: "sig",
+		};
+		const did = createDidJwk(jwk);
+		const result = resolveDidJwk(did);
+
+		expect(result.didDocument?.authentication).toHaveLength(1);
+		expect(result.didDocument?.assertionMethod).toHaveLength(1);
+		expect(result.didDocument?.capabilityInvocation).toHaveLength(1);
+		expect(result.didDocument?.capabilityDelegation).toHaveLength(1);
+		expect(result.didDocument?.keyAgreement).toBeUndefined();
+	});
+
+	it("use=enc → only keyAgreement", () => {
+		const kp = generateKeyPair("ES256");
+		const jwk: JsonWebKey = {
+			...publicKeyToJwk(kp.publicKey, "ES256"),
+			use: "enc",
+		};
+		const did = createDidJwk(jwk);
+		const result = resolveDidJwk(did);
+
+		expect(result.didDocument?.keyAgreement).toHaveLength(1);
+		expect(result.didDocument?.authentication).toBeUndefined();
+		expect(result.didDocument?.assertionMethod).toBeUndefined();
+		expect(result.didDocument?.capabilityInvocation).toBeUndefined();
+		expect(result.didDocument?.capabilityDelegation).toBeUndefined();
+	});
+
+	it("no use → all relationships present", () => {
+		const kp = generateKeyPair("ES256");
+		const jwk = publicKeyToJwk(kp.publicKey, "ES256");
+		const did = createDidJwk(jwk);
+		const result = resolveDidJwk(did);
+
+		expect(result.didDocument?.authentication).toHaveLength(1);
+		expect(result.didDocument?.assertionMethod).toHaveLength(1);
+		expect(result.didDocument?.capabilityInvocation).toHaveLength(1);
+		expect(result.didDocument?.capabilityDelegation).toHaveLength(1);
+		expect(result.didDocument?.keyAgreement).toHaveLength(1);
+	});
+
+	it("rejects private key (has d) on create", () => {
+		const jwk: JsonWebKey = {
+			kty: "EC",
+			crv: "P-256",
+			x: "test",
+			y: "test",
+			d: "private",
+		};
+		expect(() => createDidJwk(jwk)).toThrow("private key");
+	});
+
+	it("rejects private key (has d) on resolve", () => {
+		// Manually construct a did:jwk with a d member
+		const jwk: JsonWebKey = {
+			kty: "EC",
+			crv: "P-256",
+			x: "test",
+			y: "test",
+			d: "private",
+		};
+		const json = JSON.stringify(jwk);
+		const encoded = Buffer.from(json)
+			.toString("base64")
+			.replace(/\+/g, "-")
+			.replace(/\//g, "_")
+			.replace(/=+$/, "");
+		const did = `did:jwk:${encoded}`;
+
+		const result = resolveDidJwk(did);
+		expect(result.didDocument).toBeNull();
+		expect(result.didResolutionMetadata.error).toBe("invalidDid");
+	});
+
+	it("fragment is always #0", () => {
+		const kp = generateKeyPair("ES256");
+		const jwk = publicKeyToJwk(kp.publicKey, "ES256");
+		const did = createDidJwk(jwk);
+		const result = resolveDidJwk(did);
+		const vmId = result.didDocument?.verificationMethod?.[0]?.id;
+		expect(vmId).toBe(`${did}#0`);
+	});
+});

--- a/src/did/methods/jwk.ts
+++ b/src/did/methods/jwk.ts
@@ -1,0 +1,87 @@
+import {
+	base64urlToUint8Array,
+	uint8ArrayToBase64url,
+} from "../../crypto/keys";
+import type {
+	DIDDocument,
+	DIDResolutionResult,
+	JsonWebKey,
+	VerificationMethod,
+} from "../../types";
+
+export function createDidJwk(jwk: JsonWebKey): string {
+	if (jwk.d) {
+		throw new Error("Cannot create did:jwk from a private key (has d)");
+	}
+
+	const json = JSON.stringify(jwk);
+	const encoded = uint8ArrayToBase64url(new TextEncoder().encode(json));
+	return `did:jwk:${encoded}`;
+}
+
+export function resolveDidJwk(did: string): DIDResolutionResult {
+	try {
+		const prefix = "did:jwk:";
+		if (!did.startsWith(prefix)) {
+			return {
+				didDocument: null,
+				didResolutionMetadata: { error: "invalidDid" },
+				didDocumentMetadata: {},
+			};
+		}
+
+		const encoded = did.slice(prefix.length);
+		const decoded = new TextDecoder().decode(base64urlToUint8Array(encoded));
+		const jwk = JSON.parse(decoded) as JsonWebKey;
+
+		if (jwk.d) {
+			return {
+				didDocument: null,
+				didResolutionMetadata: { error: "invalidDid" },
+				didDocumentMetadata: {},
+			};
+		}
+
+		const keyId = `${did}#0`;
+
+		const verificationMethod: VerificationMethod = {
+			id: keyId,
+			type: "JsonWebKey2020",
+			controller: did,
+			publicKeyJwk: jwk,
+		};
+
+		const didDocument: DIDDocument = {
+			id: did,
+			verificationMethod: [verificationMethod],
+		};
+
+		if (jwk.use === "sig") {
+			didDocument.authentication = [keyId];
+			didDocument.assertionMethod = [keyId];
+			didDocument.capabilityInvocation = [keyId];
+			didDocument.capabilityDelegation = [keyId];
+		} else if (jwk.use === "enc") {
+			didDocument.keyAgreement = [keyId];
+		} else {
+			// No use specified — all relationships
+			didDocument.authentication = [keyId];
+			didDocument.assertionMethod = [keyId];
+			didDocument.capabilityInvocation = [keyId];
+			didDocument.capabilityDelegation = [keyId];
+			didDocument.keyAgreement = [keyId];
+		}
+
+		return {
+			didDocument,
+			didResolutionMetadata: {},
+			didDocumentMetadata: {},
+		};
+	} catch {
+		return {
+			didDocument: null,
+			didResolutionMetadata: { error: "invalidDid" },
+			didDocumentMetadata: {},
+		};
+	}
+}

--- a/src/did/methods/key.test.ts
+++ b/src/did/methods/key.test.ts
@@ -57,4 +57,30 @@ describe("did:key", () => {
 		expect(result.didDocument).toBeNull();
 		expect(result.didResolutionMetadata.error).toBeDefined();
 	});
+
+	it("creates a did:key from secp256k1 public key", () => {
+		const kp = generateKeyPair("ES256K");
+		const did = createDidKey(kp.publicKey, "ES256K");
+		expect(did).toMatch(/^did:key:z/);
+	});
+
+	it("round-trips secp256k1: create → resolve → verify key matches", () => {
+		const kp = generateKeyPair("ES256K");
+		const did = createDidKey(kp.publicKey, "ES256K");
+		const result = resolveDidKey(did);
+		expect(result.didDocument).not.toBeNull();
+		expect(result.didDocument?.id).toBe(did);
+		const jwk = result.didDocument?.verificationMethod?.[0]?.publicKeyJwk;
+		expect(jwk?.crv).toBe("secp256k1");
+		expect(jwk?.x).toBeDefined();
+		expect(jwk?.y).toBeDefined();
+	});
+
+	it("includes capabilityInvocation and capabilityDelegation in resolved docs", () => {
+		const kp = generateKeyPair("ES256");
+		const did = createDidKey(kp.publicKey, "ES256");
+		const result = resolveDidKey(did);
+		expect(result.didDocument?.capabilityInvocation).toHaveLength(1);
+		expect(result.didDocument?.capabilityDelegation).toHaveLength(1);
+	});
 });

--- a/src/did/methods/key.ts
+++ b/src/did/methods/key.ts
@@ -7,12 +7,21 @@ import type { DIDDocument, DIDResolutionResult } from "../../types";
 // Ed25519 (ed25519-pub): 0xed → varint [0xed, 0x01]
 const MULTICODEC_P256 = new Uint8Array([0x80, 0x24]);
 const MULTICODEC_ED25519 = new Uint8Array([0xed, 0x01]);
+const MULTICODEC_SECP256K1 = new Uint8Array([0xe7, 0x01]);
 
 export function createDidKey(
 	publicKey: Uint8Array,
 	algorithm: Algorithm,
 ): string {
-	const prefix = algorithm === "ES256" ? MULTICODEC_P256 : MULTICODEC_ED25519;
+	const prefixMap: Record<Algorithm, Uint8Array> = {
+		ES256: MULTICODEC_P256,
+		EdDSA: MULTICODEC_ED25519,
+		ES256K: MULTICODEC_SECP256K1,
+	};
+	const prefix = prefixMap[algorithm];
+	if (!prefix) {
+		throw new Error(`Unsupported algorithm for did:key: ${algorithm}`);
+	}
 	const multicodecKey = new Uint8Array(prefix.length + publicKey.length);
 	multicodecKey.set(prefix, 0);
 	multicodecKey.set(publicKey, prefix.length);
@@ -45,6 +54,9 @@ export function resolveDidKey(did: string): DIDResolutionResult {
 		} else if (multicodecKey[0] === 0xed && multicodecKey[1] === 0x01) {
 			algorithm = "EdDSA";
 			publicKey = multicodecKey.slice(2);
+		} else if (multicodecKey[0] === 0xe7 && multicodecKey[1] === 0x01) {
+			algorithm = "ES256K";
+			publicKey = multicodecKey.slice(2);
 		} else {
 			return {
 				didDocument: null,
@@ -68,6 +80,8 @@ export function resolveDidKey(did: string): DIDResolutionResult {
 			],
 			authentication: [keyId],
 			assertionMethod: [keyId],
+			capabilityInvocation: [keyId],
+			capabilityDelegation: [keyId],
 		};
 
 		return {

--- a/src/did/methods/web.test.ts
+++ b/src/did/methods/web.test.ts
@@ -73,4 +73,30 @@ describe("resolveDidWeb", () => {
 		expect(result.didDocument).toBeNull();
 		expect(result.didResolutionMetadata.error).toBe("notFound");
 	});
+
+	it("returns invalidDid when document id does not match DID", async () => {
+		const mockDocument = {
+			id: "did:web:wrong.com",
+			verificationMethod: [],
+		};
+
+		global.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: () => Promise.resolve(mockDocument),
+		}) as any;
+
+		const result = await resolveDidWeb("did:web:example.com");
+		expect(result.didDocument).toBeNull();
+		expect(result.didResolutionMetadata.error).toBe("invalidDid");
+	});
+
+	it("returns networkError for fetch failure", async () => {
+		global.fetch = vi
+			.fn()
+			.mockRejectedValue(new TypeError("fetch failed")) as any;
+
+		const result = await resolveDidWeb("did:web:unreachable.com");
+		expect(result.didDocument).toBeNull();
+		expect(result.didResolutionMetadata.error).toBe("networkError");
+	});
 });

--- a/src/did/methods/web.ts
+++ b/src/did/methods/web.ts
@@ -21,29 +21,39 @@ export function createDidWeb(domain: string, path?: string): string {
 }
 
 export async function resolveDidWeb(did: string): Promise<DIDResolutionResult> {
+	let response: Response;
 	try {
 		const url = didWebToUrl(did);
-		const response = await fetch(url);
-
-		if (!response.ok) {
-			return {
-				didDocument: null,
-				didResolutionMetadata: { error: "notFound" },
-				didDocumentMetadata: {},
-			};
-		}
-
-		const didDocument = (await response.json()) as DIDDocument;
+		response = await fetch(url);
+	} catch {
 		return {
-			didDocument,
-			didResolutionMetadata: {},
+			didDocument: null,
+			didResolutionMetadata: { error: "networkError" },
 			didDocumentMetadata: {},
 		};
-	} catch {
+	}
+
+	if (!response.ok) {
 		return {
 			didDocument: null,
 			didResolutionMetadata: { error: "notFound" },
 			didDocumentMetadata: {},
 		};
 	}
+
+	const didDocument = (await response.json()) as DIDDocument;
+
+	if (didDocument.id !== did) {
+		return {
+			didDocument: null,
+			didResolutionMetadata: { error: "invalidDid" },
+			didDocumentMetadata: {},
+		};
+	}
+
+	return {
+		didDocument,
+		didResolutionMetadata: {},
+		didDocumentMetadata: {},
+	};
 }

--- a/src/did/resolver.ts
+++ b/src/did/resolver.ts
@@ -1,6 +1,7 @@
 import { DIDError, ErrorCodes } from "../errors";
 import type { DIDResolutionResult } from "../types";
 import { resolveDidEbsi } from "./methods/ebsi";
+import { resolveDidJwk } from "./methods/jwk";
 import { resolveDidKey } from "./methods/key";
 import { resolveDidWeb } from "./methods/web";
 
@@ -19,6 +20,8 @@ export async function resolveDID(did: string): Promise<DIDResolutionResult> {
 	switch (method) {
 		case "key":
 			return resolveDidKey(did);
+		case "jwk":
+			return resolveDidJwk(did);
 		case "web":
 			return resolveDidWeb(did);
 		case "ebsi":
@@ -27,7 +30,7 @@ export async function resolveDID(did: string): Promise<DIDResolutionResult> {
 			throw new DIDError(
 				ErrorCodes.DID_METHOD_UNSUPPORTED,
 				`Unsupported DID method: ${method}`,
-				`The DID method "${method}" is not supported. Supported methods: key, web, ebsi.`,
+				`The DID method "${method}" is not supported. Supported methods: key, jwk, web, ebsi.`,
 			);
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,9 +31,11 @@ export type { Algorithm, KeyPair } from "./crypto";
 export { generateKeyPair, jwkToPublicKey, publicKeyToJwk } from "./crypto";
 // === DID (advanced) ===
 export {
+	createDidJwk,
 	createDidKey,
 	createDidWeb,
 	resolveDID,
+	resolveDidJwk,
 	resolveDidKey,
 	resolveDidWeb,
 } from "./did";

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,13 +91,16 @@ export interface TrustChainInfo {
 
 // === DID Types ===
 
-export type DIDMethod = "key" | "web" | "ebsi";
+export type DIDMethod = "key" | "web" | "jwk" | "ebsi";
 
 export interface DIDDocument {
 	id: string;
 	verificationMethod?: VerificationMethod[];
 	authentication?: string[];
 	assertionMethod?: string[];
+	capabilityInvocation?: string[];
+	capabilityDelegation?: string[];
+	keyAgreement?: (string | VerificationMethod)[];
 	service?: ServiceEndpoint[];
 }
 


### PR DESCRIPTION
## Summary

- **secp256k1 (ES256K)**: Full key generation, JWK conversion, and sign/verify support across `crypto/keys.ts` and `crypto/sign.ts`
- **did:jwk**: New DID method — `createDidJwk` and `resolveDidJwk` with conditional verification relationships based on `jwk.use` (`sig`/`enc`/absent)
- **did:key enhancements**: secp256k1 multicodec prefix (`0xe7 0x01`), `capabilityInvocation` and `capabilityDelegation` in all resolved DID documents
- **did:web improvements**: Validates `didDocument.id === did` after fetch, differentiates `networkError` from `notFound`
- **Wiring**: `"jwk"` added to `DIDMethod` type, resolver routing, client `did.create()`, and top-level exports

## Test plan

- [x] 227 tests pass (4 new crypto tests, 4 new did:key tests, 8 new did:jwk tests, 2 new did:web tests)
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run build` — clean ESM + CJS + DTS